### PR TITLE
feat: build match analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.streamlit/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,70 @@
 # tikidata
-tikidata - A Football Data Analytics Platforms
-streamlit_foot_radar.py
+
+## Proposition d'application : tableau de bord d'analyse de match de football
+
+Cette proposition décrit une application web qui permet d'analyser un match de football en se basant sur des données récupérées automatiquement sur le web. L'objectif est d'offrir aux utilisateurs (analystes, entraîneurs, supporters) un tableau de bord complet avec des indicateurs clés de performance (KPI) pour les équipes et les joueurs impliqués.
+
+### Fonctionnalités principales
+
+1. **Sélection du match**  
+   - Entrées : championnat, saison et noms des deux clubs.  
+   - Autocomplétion sur les champs pour limiter les erreurs de saisie et accélérer la sélection.  
+   - Possibilité d'enregistrer des combinaisons « championnat / saison / équipes » favorites.
+
+2. **Collecte des données**  
+   - Scraping automatisé des sites de statistiques football (par exemple FBref, Understat) lorsque l'utilisateur valide sa sélection.  
+   - Mise en cache des résultats pour éviter des requêtes répétées et améliorer les performances.  
+   - Gestion des erreurs (match indisponible, changement de format du site) avec messages clairs à l'utilisateur.
+
+3. **Tableau de bord des équipes**  
+   - Vue globale présentant les KPI offensifs, défensifs et de possession pour chaque équipe : tirs (total / cadrés / expected goals), passes (réussies / clés), duels gagnés, interventions défensives, zones d'attaque, etc.  
+   - Visualisations interactives (graphiques radar, heatmaps, timelines de momentum) pour comparer les performances des deux clubs.  
+   - Section « Temps forts » listant les événements importants (buts, cartons, changements) avec liens vers des extraits vidéo si disponibles.
+
+4. **Analyse individuelle des joueurs**  
+   - Liste des joueurs alignés avec leurs positions et temps de jeu.  
+   - Possibilité de sélectionner un ou plusieurs joueurs pour afficher leurs statistiques détaillées : xG, passes progressives, tacles réussis, cartes reçues, pressing, etc.  
+   - Comparaison joueur vs. moyenne de l'équipe ou de la ligue.  
+   - Heatmap de positionnement sur le terrain et graphiques d'évolution au fil du match.
+
+5. **Export et partage**  
+   - Export des rapports en PDF ou CSV.  
+   - Génération de liens partageables vers une vue en lecture seule du tableau de bord.  
+   - Intégration possible avec des outils collaboratifs (Notion, Slack) via webhooks.
+
+### Architecture technique proposée
+
+- **Frontend** : application Streamlit ou React pour construire rapidement des interfaces interactives. Streamlit permet de prototyper efficacement tout en offrant des composants prêts à l'emploi (sélecteurs, graphiques).  
+- **Backend** : API Python (FastAPI) chargée de piloter le scraping, d'orchestrer les appels aux sources de données et de servir les données nettoyées au frontend.  
+- **Scraping & données** : utilisation de bibliothèques comme `requests`, `BeautifulSoup`, `Selenium` (si nécessaire), et `pandas` pour manipuler les tableaux statistiques.  
+- **Stockage** : base de données légère (SQLite ou PostgreSQL) pour conserver l'historique des matchs et les caches.  
+- **Observabilité** : journaux structurés (loggers Python) et monitoring basique (ex. Prometheus + Grafana) pour suivre les erreurs de scraping et les performances.
+
+### Parcours utilisateur type
+
+1. L'utilisateur sélectionne le championnat (ex. Ligue 1), la saison (ex. 2023/2024) et les deux clubs (ex. PSG vs. OM).  
+2. L'application lance le scraping pour récupérer les statistiques du match ciblé.  
+3. Les données sont agrégées et normalisées avant d'être présentées dans le tableau de bord principal.  
+4. L'utilisateur explore les KPI d'équipe, puis sélectionne un ou plusieurs joueurs pour obtenir leur analyse détaillée.  
+5. Il exporte un rapport PDF et partage un lien avec son staff.
+
+### Évolutions futures
+
+- Ajout de modèles de machine learning pour détecter des schémas tactiques ou prédire des performances futures.  
+- Intégration de flux vidéo pour synchroniser les statistiques avec les actions en temps réel.  
+- Application mobile ou PWA pour consultation rapide sur le terrain.  
+- Système d'alertes personnalisées (ex. notifications en cas d'anomalie ou de performance notable).
+
+Cette application offrirait une plateforme complète pour analyser un match de football à partir de données disponibles publiquement, avec un accent sur la visualisation claire des KPI et la flexibilité d'explorer les performances individuelles des joueurs.
+
+## Lancer le tableau de bord Streamlit
+
+1. Installez les dépendances Python (de préférence dans un environnement virtuel):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Démarrez l'application Streamlit:
+   ```bash
+   streamlit run streamlit_app.py
+   ```
+3. Dans l'interface, choisissez le championnat, la saison et les clubs à analyser, puis cliquez sur **Analyser le match** pour lancer le scraping et explorer les KPI détaillés.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for the Tikidata football analytics demo app."""

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,71 @@
+"""Application constants for supported leagues and seasons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class LeagueConfig:
+    """Configuration describing how to access an ESPN soccer competition."""
+
+    name: str
+    espn_slug: str
+    aliases: tuple[str, ...]
+    seasons: range
+
+    @property
+    def canonical(self) -> str:
+        return self.aliases[0] if self.aliases else self.name
+
+
+SUPPORTED_LEAGUES: Dict[str, LeagueConfig] = {
+    "Premier League": LeagueConfig(
+        name="Premier League",
+        espn_slug="eng.1",
+        aliases=("premier league", "epl", "premiership"),
+        seasons=range(2019, 2026),
+    ),
+    "Ligue 1": LeagueConfig(
+        name="Ligue 1",
+        espn_slug="fra.1",
+        aliases=("ligue 1", "ligue1", "france"),
+        seasons=range(2019, 2026),
+    ),
+    "La Liga": LeagueConfig(
+        name="La Liga",
+        espn_slug="esp.1",
+        aliases=("la liga", "laliga", "liga"),
+        seasons=range(2019, 2026),
+    ),
+    "Serie A": LeagueConfig(
+        name="Serie A",
+        espn_slug="ita.1",
+        aliases=("serie a", "italy", "seriea"),
+        seasons=range(2019, 2026),
+    ),
+    "Bundesliga": LeagueConfig(
+        name="Bundesliga",
+        espn_slug="ger.1",
+        aliases=("bundesliga", "germany"),
+        seasons=range(2019, 2026),
+    ),
+}
+
+
+def iter_all_aliases() -> Iterable[tuple[str, LeagueConfig]]:
+    """Yield every supported league alias and its configuration."""
+
+    for league in SUPPORTED_LEAGUES.values():
+        for alias in (league.name.lower(), *league.aliases):
+            yield alias, league
+
+
+def list_season_labels(config: LeagueConfig) -> List[str]:
+    """Return a display friendly list of available seasons for a league."""
+
+    seasons = []
+    for year in config.seasons:
+        seasons.append(f"{year}-{year + 1}")
+    return seasons

--- a/app/espn_client.py
+++ b/app/espn_client.py
@@ -1,0 +1,53 @@
+"""Lightweight HTTP client that wraps ESPN's public soccer endpoints."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Optional
+
+import requests
+
+ESPN_BASE_URL = "https://site.api.espn.com/apis/site/v2/sports/soccer"
+
+
+class ESPNError(RuntimeError):
+    """Raised when ESPN returns an error payload."""
+
+
+class ESPNClient:
+    """HTTP wrapper around a subset of the unofficial ESPN soccer API."""
+
+    def __init__(self, session: Optional[requests.Session] = None) -> None:
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+                ),
+                "Accept": "application/json",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+        )
+
+    def _get(self, path: str, *, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = f"{ESPN_BASE_URL}/{path}"
+        response = self.session.get(url, params=params, timeout=15)
+        response.raise_for_status()
+        data: Dict[str, Any] = response.json()
+        if isinstance(data, dict) and data.get("error"):
+            raise ESPNError(str(data["error"]))
+        return data
+
+    @lru_cache(maxsize=32)
+    def fetch_league_teams(self, league_slug: str) -> Iterable[Dict[str, Any]]:
+        data = self._get(f"{league_slug}/teams")
+        return data["sports"][0]["leagues"][0]["teams"]
+
+    @lru_cache(maxsize=128)
+    def fetch_team_schedule(self, league_slug: str, team_id: str, season: int) -> Iterable[Dict[str, Any]]:
+        data = self._get(f"{league_slug}/teams/{team_id}/schedule", params={"season": season})
+        return data.get("events", [])
+
+    def fetch_match_summary(self, league_slug: str, event_id: str) -> Dict[str, Any]:
+        return self._get(f"{league_slug}/summary", params={"event": event_id})

--- a/app/match_service.py
+++ b/app/match_service.py
@@ -1,0 +1,205 @@
+"""High level service that orchestrates the match data scraping workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .constants import LeagueConfig, SUPPORTED_LEAGUES
+from .espn_client import ESPNClient
+from .utils import find_best_match, parse_numeric, slugify
+
+
+class TeamLookupError(RuntimeError):
+    """Raised when the given team name cannot be matched to a league entry."""
+
+
+class MatchLookupError(RuntimeError):
+    """Raised when no event matches the provided teams and season."""
+
+
+@dataclass
+class Scoreline:
+    team: str
+    team_id: str
+    score: int
+    home_away: str
+    record: Optional[str]
+    possession: Optional[float]
+
+
+@dataclass
+class MatchMetadata:
+    event_id: str
+    competition: str
+    status: str
+    start_time: datetime
+    venue: Optional[str]
+    attendance: Optional[str]
+    officials: List[str]
+    scoreline: Dict[str, Scoreline]
+
+
+@dataclass
+class MatchData:
+    metadata: MatchMetadata
+    team_stats: pd.DataFrame
+    player_stats: pd.DataFrame
+    key_events: pd.DataFrame
+
+
+class MatchService:
+    """Service responsible for fetching and transforming match analytics data."""
+
+    def __init__(self, client: Optional[ESPNClient] = None) -> None:
+        self.client = client or ESPNClient()
+
+    def _resolve_league(self, league_name: str) -> LeagueConfig:
+        if league_name in SUPPORTED_LEAGUES:
+            return SUPPORTED_LEAGUES[league_name]
+        league_slug = slugify(league_name)
+        for config in SUPPORTED_LEAGUES.values():
+            if league_slug in {slugify(config.name), *(slugify(alias) for alias in config.aliases)}:
+                return config
+        raise ValueError(f"Championnat non pris en charge : {league_name}")
+
+    def _resolve_team(self, league: LeagueConfig, raw_name: str) -> Dict:
+        teams = list(self.client.fetch_league_teams(league.espn_slug))
+        candidate = find_best_match(raw_name, [team["team"]["displayName"] for team in teams])
+        if not candidate:
+            raise TeamLookupError(f"Impossible de trouver l'équipe '{raw_name}'.")
+        return next(team for team in teams if team["team"]["displayName"] == candidate)
+
+    def _season_to_year(self, season: str) -> int:
+        season = season.strip()
+        if "-" in season:
+            start_year = season.split("-")[0]
+            return int(start_year)
+        return int(season)
+
+    def _find_event(self, league: LeagueConfig, season_year: int, home_team_id: str, away_team_id: str) -> Dict:
+        def _search(team_id: str) -> Optional[Dict]:
+            events = self.client.fetch_team_schedule(league.espn_slug, team_id, season_year)
+            for event in events:
+                if event.get("league", {}).get("slug") != league.espn_slug:
+                    continue
+                competitors = event["competitions"][0]["competitors"]
+                if self._event_matches(competitors, home_team_id, away_team_id):
+                    return event
+            return None
+
+        event = _search(home_team_id) or _search(away_team_id)
+        if not event:
+            raise MatchLookupError("Aucun match trouvé pour ces critères.")
+        return event
+
+    @staticmethod
+    def _event_matches(competitors: List[Dict], home_team_id: str, away_team_id: str) -> bool:
+        seen_home = seen_away = False
+        for competitor in competitors:
+            team_id = str(competitor["team"]["id"])
+            home_away = competitor.get("homeAway")
+            if team_id == str(home_team_id) and home_away == "home":
+                seen_home = True
+            if team_id == str(away_team_id) and home_away == "away":
+                seen_away = True
+        return seen_home and seen_away
+
+    def load_match(self, league_name: str, season: str, home_team: str, away_team: str) -> MatchData:
+        league = self._resolve_league(league_name)
+        home = self._resolve_team(league, home_team)
+        away = self._resolve_team(league, away_team)
+        season_year = self._season_to_year(season)
+        event = self._find_event(league, season_year, home["team"]["id"], away["team"]["id"])
+        summary = self.client.fetch_match_summary(league.espn_slug, event["id"])
+        metadata = self._build_metadata(summary)
+        team_stats = self._build_team_stats(summary)
+        player_stats = self._build_player_stats(summary)
+        key_events = self._build_key_events(summary)
+        return MatchData(metadata=metadata, team_stats=team_stats, player_stats=player_stats, key_events=key_events)
+
+    def _build_metadata(self, summary: Dict) -> MatchMetadata:
+        competition = summary["header"]["competitions"][0]
+        scoreline: Dict[str, Scoreline] = {}
+        for competitor in competition["competitors"]:
+            record = None
+            if competitor.get("record"):
+                record = ", ".join(r.get("summary", "") for r in competitor["record"])
+            possession = None
+            if competitor.get("possession") and competitor["possession"].get("displayValue"):
+                possession = parse_numeric(str(competitor["possession"]["displayValue"]))
+            scoreline[competitor["homeAway"]] = Scoreline(
+                team=competitor["team"]["displayName"],
+                team_id=str(competitor["team"]["id"]),
+                score=int(competitor.get("score", 0)),
+                home_away=competitor.get("homeAway", ""),
+                record=record,
+                possession=possession,
+            )
+        start_time = datetime.fromisoformat(competition["date"].replace("Z", "+00:00"))
+        officials = [official.get("displayName") for official in competition.get("officials", []) if official.get("displayName")]
+        attendance = competition.get("attendance")
+        return MatchMetadata(
+            event_id=str(competition["id"]),
+            competition=competition.get("league", {}).get("name", ""),
+            status=competition.get("status", {}).get("type", {}).get("description", ""),
+            start_time=start_time,
+            venue=competition.get("venue", {}).get("fullName"),
+            attendance=attendance,
+            officials=officials,
+            scoreline=scoreline,
+        )
+
+    def _build_team_stats(self, summary: Dict) -> pd.DataFrame:
+        records: List[Dict[str, object]] = []
+        for team in summary.get("boxscore", {}).get("teams", []):
+            row: Dict[str, object] = {"Équipe": team["team"]["displayName"]}
+            for stat in team.get("statistics", []):
+                row[stat["label"]] = stat.get("displayValue")
+            records.append(row)
+        df = pd.DataFrame(records)
+        numeric_columns = [col for col in df.columns if col != "Équipe"]
+        for column in numeric_columns:
+            df[column] = df[column].apply(parse_numeric)
+        percentage_columns = [col for col in df.columns if "%(" in col.lower() or "%" in col]
+        for column in percentage_columns:
+            df[column] = df[column].apply(lambda x: x * 100 if x is not None and x <= 1 else x)
+        return df
+
+    def _build_player_stats(self, summary: Dict) -> pd.DataFrame:
+        rows: List[Dict[str, object]] = []
+        for team in summary.get("rosters", []):
+            team_name = team["team"]["displayName"]
+            for player in team.get("roster", []):
+                row: Dict[str, object] = {
+                    "Équipe": team_name,
+                    "Joueur": player["athlete"]["displayName"],
+                    "N°": player.get("jersey"),
+                    "Titulaire": bool(player.get("starter")),
+                    "Poste": (player.get("position") or {}).get("abbreviation"),
+                }
+                for stat in player.get("stats", []):
+                    row[stat["displayName"]] = stat.get("displayValue")
+                rows.append(row)
+        df = pd.DataFrame(rows)
+        stat_cols = [col for col in df.columns if col not in {"Équipe", "Joueur", "N°", "Titulaire", "Poste"}]
+        for column in stat_cols:
+            df[column] = df[column].apply(parse_numeric)
+        return df
+
+    def _build_key_events(self, summary: Dict) -> pd.DataFrame:
+        events_data: List[Dict[str, object]] = []
+        for event in summary.get("keyEvents", []):
+            events_data.append(
+                {
+                    "Minute": event.get("clock", {}).get("displayValue"),
+                    "Période": event.get("period", {}).get("displayValue"),
+                    "Type": (event.get("type") or {}).get("text"),
+                    "Description": event.get("text"),
+                }
+            )
+        df = pd.DataFrame(events_data)
+        return df

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers for name normalisation and numeric parsing."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from difflib import get_close_matches
+from typing import Iterable, Optional
+
+
+def slugify(value: str) -> str:
+    """Return a slug-like lowercase version of ``value`` without accents."""
+
+    value = unicodedata.normalize("NFKD", value)
+    value = value.encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^a-zA-Z0-9]+", " ", value)
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def find_best_match(query: str, candidates: Iterable[str]) -> Optional[str]:
+    """Return the best fuzzy match from ``candidates`` for ``query``."""
+
+    if not query:
+        return None
+    query_slug = slugify(query)
+    candidate_map = {slugify(candidate): candidate for candidate in candidates}
+    if query_slug in candidate_map:
+        return candidate_map[query_slug]
+    for slug, original in candidate_map.items():
+        if query_slug in slug or slug in query_slug:
+            return original
+    matches = get_close_matches(query_slug, candidate_map.keys(), n=1, cutoff=0.5)
+    if not matches:
+        return None
+    return candidate_map[matches[0]]
+
+
+def parse_numeric(value: str) -> Optional[float]:
+    """Attempt to parse ``value`` into a float if possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    value = value.strip()
+    if not value or value in {"-", "--", "N/A"}:
+        return None
+    value = value.replace("%", "")
+    try:
+        return float(value)
+    except ValueError:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas>=2.3
+plotly>=6.0
+requests>=2.32
+streamlit>=1.50

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,138 @@
+"""Streamlit dashboard that showcases scraped football match analytics."""
+
+from __future__ import annotations
+
+from datetime import timezone
+from typing import List
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from app.constants import SUPPORTED_LEAGUES, list_season_labels
+from app.match_service import MatchLookupError, MatchService, TeamLookupError
+
+
+st.set_page_config(
+    page_title="Analyse de match football",
+    page_icon="⚽",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+
+def display_team_kpis(team_df: pd.DataFrame, home_name: str, away_name: str) -> None:
+    if team_df.empty or "Équipe" not in team_df.columns:
+        st.warning("Aucune statistique d'équipe disponible.")
+        return
+    kpi_candidates = [
+        ("SHOTS", "Tirs"),
+        ("ON GOAL", "Tirs cadrés"),
+        ("Possession", "Possession %"),
+        ("Pass Completion %", "Précision des passes %"),
+        ("Tackles", "Tacles"),
+    ]
+    data = {}
+    for label, title in kpi_candidates:
+        if label in team_df.columns:
+            data[title] = team_df[["Équipe", label]].rename(columns={label: title})
+    if not data:
+        st.warning("Les statistiques clés ne sont pas disponibles.")
+        return
+
+    tabs = st.tabs(list(data.keys()))
+    for tab, (stat_name, df) in zip(tabs, data.items()):
+        with tab:
+            fig = go.Figure()
+            home_series = df[df["Équipe"] == home_name][stat_name]
+            away_series = df[df["Équipe"] == away_name][stat_name]
+            home_value = home_series.iloc[0] if not home_series.empty else 0
+            away_value = away_series.iloc[0] if not away_series.empty else 0
+            fig.add_bar(name=home_name, x=[home_name], y=[home_value])
+            fig.add_bar(name=away_name, x=[away_name], y=[away_value])
+            fig.update_layout(
+                barmode="group",
+                showlegend=False,
+                yaxis_title=stat_name,
+                template="plotly_white",
+                height=340,
+            )
+            st.plotly_chart(fig, use_container_width=True)
+
+
+def show_player_filters(players: pd.DataFrame) -> None:
+    if players.empty:
+        st.warning("Les statistiques individuelles ne sont pas disponibles.")
+        return
+    teams = sorted(players["Équipe"].unique())
+    selected_team = st.selectbox("Sélectionnez une équipe", teams)
+    filtered = players[players["Équipe"] == selected_team]
+    player_names: List[str] = filtered["Joueur"].tolist()
+    selected_players = st.multiselect("Choisissez un ou plusieurs joueurs", player_names, default=player_names[:3])
+    if not selected_players:
+        st.info("Sélectionnez au moins un joueur pour afficher ses données.")
+        return
+    table = filtered[filtered["Joueur"].isin(selected_players)]
+    st.dataframe(table.set_index("Joueur"), use_container_width=True)
+
+
+service = MatchService()
+
+st.title("Tableau de bord d'analyse de match")
+st.caption("Les données sont récupérées en direct depuis les endpoints publics d'ESPN.")
+
+with st.sidebar:
+    st.header("Paramètres")
+    league_name = st.selectbox("Championnat", list(SUPPORTED_LEAGUES.keys()))
+    league_config = SUPPORTED_LEAGUES[league_name]
+    seasons = list_season_labels(league_config)
+    default_season = seasons[-2] if len(seasons) >= 2 else seasons[-1]
+    season = st.selectbox("Saison", seasons, index=seasons.index(default_season))
+    home_team = st.text_input("Équipe à domicile", "Paris Saint-Germain")
+    away_team = st.text_input("Équipe à l'extérieur", "Olympique de Marseille")
+    run = st.button("Analyser le match")
+
+if run:
+    try:
+        with st.spinner("Chargement des données du match..."):
+            match = service.load_match(league_name, season, home_team, away_team)
+    except ValueError as exc:
+        st.error(str(exc))
+    except TeamLookupError as exc:
+        st.error(str(exc))
+    except MatchLookupError as exc:
+        st.error(str(exc))
+    else:
+        metadata = match.metadata
+        home = metadata.scoreline.get("home")
+        away = metadata.scoreline.get("away")
+        if not home or not away:
+            st.warning("Impossible d'afficher le score du match.")
+        else:
+            st.subheader(f"{home.team} vs {away.team}")
+            col1, col2, col3 = st.columns(3)
+            with col1:
+                st.metric("Score", f"{home.score} - {away.score}")
+            with col2:
+                kickoff = metadata.start_time.astimezone(timezone.utc)
+                st.metric("Date", kickoff.strftime("%d %b %Y %H:%M UTC"))
+            with col3:
+                location = metadata.venue or "-"
+                st.metric("Stade", location)
+
+            st.markdown("### Statistiques d'équipe clés")
+            display_team_kpis(match.team_stats, home.team, away.team)
+
+            st.markdown("### Statistiques complètes des équipes")
+            st.dataframe(match.team_stats.set_index("Équipe"), use_container_width=True)
+
+            st.markdown("### Analyse des joueurs")
+            show_player_filters(match.player_stats)
+
+            if not match.key_events.empty:
+                st.markdown("### Temps forts du match")
+                st.dataframe(match.key_events, use_container_width=True)
+            else:
+                st.info("Aucun temps fort disponible pour ce match.")
+else:
+    st.info("Configurez vos paramètres dans la barre latérale puis cliquez sur *Analyser le match*.")


### PR DESCRIPTION
## Summary
- add an ESPN-backed scraping service and utilities for resolving leagues, teams, and match data
- build a Streamlit dashboard that visualises scraped team KPIs, player stats, and key events
- document how to install dependencies and launch the dashboard demo

## Testing
- python - <<'PY'
from app.match_service import MatchService
service = MatchService()
match = service.load_match('Ligue 1', '2023-2024', 'Paris Saint-Germain', 'Marseille')
print('event_id:', match.metadata.event_id)
print('teams:', list(match.team_stats['Équipe']))
print('players:', len(match.player_stats))
print('key events:', len(match.key_events))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e56bcba14c83318e41a342398f03a7